### PR TITLE
Use `gb_sets` in place of the `PQ` module in Day 15

### DIFF
--- a/2021/day-15-gb_sets.livemd
+++ b/2021/day-15-gb_sets.livemd
@@ -1,0 +1,129 @@
+<!-- vim: syntax=markdown -->
+
+# Day 15
+
+## Setup
+
+* [Stream recording](https://www.twitch.tv/videos/1235179913)
+
+```elixir
+Mix.install([
+  {:kino, "~> 0.4.1"}
+])
+```
+
+```elixir
+input = Kino.Input.textarea("Input")
+```
+
+```elixir
+defmodule PQ do
+  def new() do
+    []
+  end
+
+  def add([{cur_weight, _} | _] = list, value, weight)
+      when weight <= cur_weight,
+      do: [{weight, value} | list]
+
+  def add([head | tail], value, weight),
+    do: [head | add(tail, value, weight)]
+
+  def add([], value, weight),
+    do: [{weight, value}]
+end
+
+defmodule Dijkstra do
+  def shortest(graph) do
+    distances = %{{0, 0} => 0}
+    queue = PQ.add(PQ.new(), {0, 0}, 0)
+    target = Enum.max(Map.keys(graph))
+    recur(graph, distances, queue, target)
+  end
+
+  defp recur(graph, distances, queue, target) do
+    [{_, {row, col} = u} | queue] = queue
+
+    if u == target do
+      distances[u]
+    else
+      neighbours = [{row - 1, col}, {row + 1, col}, {row, col - 1}, {row, col + 1}]
+
+      {distances, queue} =
+        for v <- neighbours,
+            Map.has_key?(graph, v),
+            distance_from_source = distances[u] + graph[v],
+            distance_from_source < Map.get(distances, v, :infinity),
+            reduce: {distances, queue} do
+          {distances, queue} ->
+            distances = Map.put(distances, v, distance_from_source)
+            queue = PQ.add(queue, v, distance_from_source)
+            {distances, queue}
+        end
+
+      recur(graph, distances, queue, target)
+    end
+  end
+end
+
+lines = input |> Kino.Input.read() |> String.split("\n", trim: true)
+
+grid =
+  for {line, row} <- Enum.with_index(lines, 0),
+      {char, col} <- Enum.with_index(String.to_charlist(line)),
+      into: %{} do
+    {{row, col}, char - ?0}
+  end
+```
+
+## Part 1
+
+```elixir
+Dijkstra.shortest(grid)
+```
+
+## Part 2
+
+```elixir
+defmodule Grid do
+  def expand(grid, n) do
+    {height, width} = Enum.max(Map.keys(grid))
+
+    {grid, width, _} =
+      for _ <- 2..n, reduce: {grid, width + 1, 1} do
+        {grid, offset, bump} ->
+          grid =
+            for row <- 0..height, col <- 0..width, reduce: grid do
+              acc ->
+                value = grid[{row, col}] + bump
+                value = if value >= 10, do: value - 9, else: value
+                Map.put(acc, {row, col + offset}, value)
+            end
+
+          {grid, offset + width + 1, bump + 1}
+      end
+
+    width = width - 1
+
+    {grid, _, _} =
+      for _ <- 2..n, reduce: {grid, height + 1, 1} do
+        {grid, offset, bump} ->
+          grid =
+            for row <- 0..height, col <- 0..width, reduce: grid do
+              acc ->
+                value = grid[{row, col}] + bump
+                value = if value >= 10, do: value - 9, else: value
+                Map.put(acc, {row + offset, col}, value)
+            end
+
+          {grid, offset + height + 1, bump + 1}
+      end
+
+    grid
+  end
+end
+
+grid
+|> Grid.expand(5)
+|> Dijkstra.shortest()
+```

--- a/2021/day-15-gb_sets.livemd
+++ b/2021/day-15-gb_sets.livemd
@@ -17,51 +17,34 @@ input = Kino.Input.textarea("Input")
 ```
 
 ```elixir
-defmodule PQ do
-  def new() do
-    []
-  end
-
-  def add([{cur_weight, _} | _] = list, value, weight)
-      when weight <= cur_weight,
-      do: [{weight, value} | list]
-
-  def add([head | tail], value, weight),
-    do: [head | add(tail, value, weight)]
-
-  def add([], value, weight),
-    do: [{weight, value}]
-end
-
 defmodule Dijkstra do
   def shortest(graph) do
-    distances = %{{0, 0} => 0}
-    queue = PQ.add(PQ.new(), {0, 0}, 0)
+    seen = MapSet.new([{0, 0}])
+    queue = :gb_sets.insert({0, {0, 0}}, :gb_sets.empty())
     target = Enum.max(Map.keys(graph))
-    recur(graph, distances, queue, target)
+    recur(graph, seen, queue, target)
   end
 
-  defp recur(graph, distances, queue, target) do
-    [{_, {row, col} = u} | queue] = queue
+  defp recur(graph, seen, queue, target) do
+    {{dist, {row, col} = u}, queue} = :gb_sets.take_smallest(queue)
 
     if u == target do
-      distances[u]
+      dist
     else
       neighbours = [{row - 1, col}, {row + 1, col}, {row, col - 1}, {row, col + 1}]
 
-      {distances, queue} =
+      {seen, queue} =
         for v <- neighbours,
             Map.has_key?(graph, v),
-            distance_from_source = distances[u] + graph[v],
-            distance_from_source < Map.get(distances, v, :infinity),
-            reduce: {distances, queue} do
-          {distances, queue} ->
-            distances = Map.put(distances, v, distance_from_source)
-            queue = PQ.add(queue, v, distance_from_source)
-            {distances, queue}
+            not MapSet.member?(seen, v),
+            reduce: {seen, queue} do
+          {seen, queue} ->
+            seen = MapSet.put(seen, v)
+            queue = :gb_sets.insert({dist + graph[v], v}, queue)
+            {seen, queue}
         end
 
-      recur(graph, distances, queue, target)
+      recur(graph, seen, queue, target)
     end
   end
 end


### PR DESCRIPTION
Oi, José! :wave:

The original idea (during the last minutes of the livestream) was to use [`gb_trees`](https://www.erlang.org/doc/man/gb_trees.html). But [`gb_sets`](https://www.erlang.org/doc/man/gb_sets.html) is a better option since there's actually no value to store at any given key (we still need the `seen` MapSet for fast lookups)

This PR creates a new file. Please, LMK if you'd like me to change that or any other aspect :slightly_smiling_face:

p.s.: :purple_heart: thanks for livestreaming! It's being fun!
